### PR TITLE
Updated app.listen to cast port to a number due to bug with heroku de…

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,6 @@ app.post('/slack/events', parseBody, verifySignature, challengeCheck, async (req
     await slackEvent.processEvent(req);
 });
 
-app.listen(port, () => {
+app.listen(Number(port), () => {
     console.log(`Server is listening on port ${port}`);
 });


### PR DESCRIPTION
…ployment. Heroku web dyno will crash if port is passed as a string or isn't cast to a number.